### PR TITLE
Match mongod_repl_master to inventory_hostname

### DIFF
--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -75,7 +75,7 @@
 
 - name: Create the file to initialize the mongod replica set
   template: src=repset_init.j2 dest=/tmp/repset_init.js
-  when: mongod_replication and mongod_repl_master == ansible_hostname
+  when: mongod_replication and (mongod_repl_master == inventory_hostname or mongod_repl_master == ansible_hostname)
 
 - name: Pause for a while
   pause: seconds=40
@@ -83,4 +83,4 @@
 
 - name: Initialize the replication set
   shell: /usr/bin/mongo --port "{{ mongod_port }}" /tmp/repset_init.js 
-  when: mongod_replication and mongod_repl_master == ansible_hostname
+  when: mongod_replication and (mongod_repl_master == inventory_hostname or mongod_repl_master == ansible_hostname)


### PR DESCRIPTION
It's convenient to match `mongod_repl_master` to inventory_hostname in addition
to ansible_hostname in the tasks. ansible_hostname is pulled from the system
hostname, and that's not always the most practical way to reference a
host in a playbook.