### PR TITLE
Add mongod_no_http_interface variable

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,6 +25,7 @@ The variables that can be passed to this role and a brief description about them
     mongod_repl_servers: []             # The hostname's of the server where the data should be replicated.
     mongod_repl_master: "localhost"     # The host which should act as the repl master during configuration.
     mongod_replset_name: rs0            # The name of the replica set.
+    mongod_no_http_interface: false     # Enable or disable the mongod HTTP interface
 
 
 Examples

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -10,3 +10,4 @@ mongod_replication: false
 mongod_repl_servers: []
 mongod_repl_master: "localhost"
 mongod_replset_name: rs0
+mongod_no_http_interface: false

--- a/templates/mongod.conf.j2
+++ b/templates/mongod.conf.j2
@@ -15,7 +15,7 @@ fork = false
 
 logappend=true
 
-
+nohttpinterface = {{ mongod_no_http_interface }}
 port = {{ mongod_port }}
 
 dbpath={{ mongod_datadir_prefix }}/mongo-{{ mongod_port }}


### PR DESCRIPTION
Allows for enabling or disabling mongod's HTTP interface with
`mongod_no_http_interface`. By default, this variable is set to
'false', which enables the interface.
