### PR TITLE
Fixing an issue with new Ansible 2.0.0 parser

### DIFF
--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -33,7 +33,7 @@
   user: name={{ mongo_user }} comment="MongoD"
 
 - name: make sure the hostname is available in /etc/hosts
-  lineinfile: dest=/etc/hosts regexp="{{ ansible_hostname }}" line="{{ hostvars[inventory_hostname].ansible_default_ipv4.address + " " + ansible_hostname }}" state=present
+  lineinfile: dest=/etc/hosts regexp="{{ ansible_hostname }}" line="{{ hostvars[inventory_hostname].ansible_default_ipv4.address + ' ' + ansible_hostname }}" state=present
 
 - name: Create the data directory for the mongod
   file: path={{ mongod_datadir_prefix }} owner={{ mongo_user }} group={{ mongo_group }} state=directory


### PR DESCRIPTION
I switched to experimental branch of ansible 2.0.0 and got an issue with your module. Here is a proposal of how to fix the issue.

The error was:

```
ERROR! this task 'lineinfile' has extra params, which is only allowed in the following modules: command, shell, script, include, include_vars, add_host, group_by, set_fact, raw, meta

 The error appears to have been in '/data/jenkins/workspace/Infrastructure-provision-environment/ansible/roles/mongo_mongod/tasks/main.yml': line 35, column 3, but may
 be elsewhere in the file depending on the exact syntax problem.

 The offending line appears to be:


 - name: make sure the hostname is available in /etc/hosts
   ^ here
```
