### PR TITLE
Double quotation mark within double quoted string value

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,29 @@
+---
+language: python
+python: "2.7"
+
+# Use the new container infrastructure
+sudo: false
+
+# Install ansible
+addons:
+  apt:
+    packages:
+    - python-pip
+
+install:
+  # Install ansible
+  - pip install ansible>=2.0
+
+  # Check ansible version
+  - ansible --version
+
+  # Create ansible.cfg with correct roles_path
+  - printf '[defaults]\nroles_path=../' >ansible.cfg
+
+script:
+  # Basic role syntax check
+  - ansible-playbook tests/test.yml -i tests/inventory --syntax-check
+
+notifications:
+  webhooks: https://galaxy.ansible.com/api/v1/notifications/

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -16,7 +16,7 @@
 - name: Install the repository for Ubuntu mongodb
   apt_repository: repo="deb http://downloads-distro.mongodb.org/repo/ubuntu-upstart dist 10gen" state=present
   when: ansible_os_family == "Debian"
-  
+
 - name: Install the libselinux module
   yum: name=libselinux-python state=installed
   when: ansible_os_family == "RedHat"
@@ -33,7 +33,7 @@
   user: name={{ mongo_user }} comment="MongoD"
 
 - name: make sure the hostname is available in /etc/hosts
-  lineinfile: dest=/etc/hosts regexp="{{ ansible_hostname }}" line="{{ hostvars[inventory_hostname].ansible_default_ipv4.address + " " + ansible_hostname }}" state=present
+  lineinfile: dest=/etc/hosts regexp="{{ ansible_hostname }}" line="{{ hostvars[inventory_hostname].ansible_default_ipv4.address + ' ' + ansible_hostname }}" state=present
 
 - name: Create the data directory for the mongod
   file: path={{ mongod_datadir_prefix }} owner={{ mongo_user }} group={{ mongo_group }} state=directory
@@ -85,5 +85,5 @@
   when: mongod_replication
 
 - name: Initialize the replication set
-  shell: /usr/bin/mongo --port "{{ mongod_port }}" /tmp/repset_init.js 
+  shell: /usr/bin/mongo --port "{{ mongod_port }}" /tmp/repset_init.js
   when: mongod_replication and (mongod_repl_master == inventory_hostname or mongod_repl_master == ansible_hostname)

--- a/tests/inventory
+++ b/tests/inventory
@@ -1,0 +1,1 @@
+localhost

--- a/tests/test.yml
+++ b/tests/test.yml
@@ -1,0 +1,5 @@
+---
+- hosts: localhost
+  remote_user: root
+  roles:
+    - mongo_mongod


### PR DESCRIPTION
The value of parameter `line` in the lineinfile task contains double quotation marks. In Ansible 2, it complains:
```
ERROR! this task 'lineinfile' has extra params, which is only allowed in the following modules: command, shell, script, include, include_vars, add_host, group_by, set_fact, raw, meta

The error appears to have been in '/Users/harry/workspace/ansible_roles/mongo_mongod/tasks/main.yml': line 35, column 3, but may
be elsewhere in the file depending on the exact syntax problem.

The offending line appears to be:

    tasks:
      - name: make sure the hostname is available in /etc/hosts
        ^ here
```

Changing them to single quotation marks. Also add basic tests.